### PR TITLE
Paar dingen: de issue was een beetje vaag geformuleerd dus ik heb het…

### DIFF
--- a/client/src/pages/MyGroups.js
+++ b/client/src/pages/MyGroups.js
@@ -8,6 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import Toolbar from '@material-ui/core/Toolbar';
 import Field from '../components/Field';
 import Paper from '@material-ui/core/Paper';
+import queryString from "query-string";
 
 class MyGroups extends Component {
 
@@ -18,9 +19,25 @@ class MyGroups extends Component {
 		}
 	}
 
-	componentWillMount() {
+	static getDerivedStateFromProps(nextProps, prevState) {
+		let values = queryString.parse(nextProps.location.search);
+		return {
+			...prevState,
+			...{
+				filterMethod: values.filter ? values.filter : "period2",
+			}
+		};
+	}
+
+	componentDidMount() {
 		this.props.getParticipatingGroups();
 	}
+
+	handleFilterChange = event => {
+		this.props.history.push({
+			search: "filter=" + event.target.value,
+		});
+	};
 
 	render() {
 		let content;
@@ -72,7 +89,7 @@ class MyGroups extends Component {
 								{ label: "Blok 2", value: "period2" },
 								{ label: "Blok 3", value: "period3" },
 								{ label: "Blok 4", value: "period4" }]}
-							onChange={(event) => { this.setState({ filterMethod: event.target.value }) }}
+							onChange={this.handleFilterChange}
 						/>
 					</Toolbar>
 				</Paper>


### PR DESCRIPTION
… geinterpreteerd als zorg ervoor dat bij mijn groepen de url hetzelfde werkt als bij aanbod. Ik heb de filter standaard op period 2 gezet, dat was hiervoor ook al zo, weet niet of dit de bedoeling is. En bij groepen zit alleen fiter in de url niet sort omdat dat daar niet gebruikt word. En als laatse, ik heb een bug gevonden. Dit doet zich alleen voor bij de aanbod pagina, als je de pagina voor het eerst aanroept, en er dus geen dingen in de query staan, daarna een filter toepast en daarna terug gaat crasht hij een soort van.