### PR TITLE
Fix datapage sorting with null or undefined

### DIFF
--- a/client/src/pages/DataPage.js
+++ b/client/src/pages/DataPage.js
@@ -63,7 +63,7 @@ class DataPage extends Component {
 			//Only sort the slice 1-table.length because the header has to stick
 			a = a[column];
 			b = b[column];
-			const cmp = (a===null || a===undefined)-(b===null || b===undefined) || +(a>b)||-(a<b);
+			const cmp = (b===null || b===undefined) - (a===null || a===undefined)|| +(a>b)||-(a<b);
 			return order === "asc" ? cmp : -cmp;
 		}));
 

--- a/client/src/pages/DataPage.js
+++ b/client/src/pages/DataPage.js
@@ -61,7 +61,9 @@ class DataPage extends Component {
 
 		table = [table[0]].concat(table.slice(1, table.length).sort((a, b) => {
 			//Only sort the slice 1-table.length because the header has to stick
-			let cmp = a[column] > b[column] ? 1 : (a[column] < b[column] ? -1 : 0);
+			a = a[column];
+			b = b[column];
+			const cmp = (a===null || a===undefined)-(b===null || b===undefined) || +(a>b)||-(a<b);
 			return order === "asc" ? cmp : -cmp;
 		}));
 


### PR DESCRIPTION
Nu geeft hij undefined of null values ook een plek in de sort, namelijk onderaan